### PR TITLE
bumped govmomi to v0.18.0 and base container to golang:1.10.2-alpine3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.10.1-alpine3.7
+FROM golang:1.10.2-alpine3.7
 
-ARG GOVMOMI_CHECKOUT=dee49fa3694c5aff05e4b340b0686772f65c1fe1
+ARG GOVMOMI_CHECKOUT="tags/v0.18.0"
 
 ADD requirements.txt /root/requirements.txt
 


### PR DESCRIPTION
this will require updating a couple of the vmware_guest* module tests (need to revert the `False` back to `True` from [ansible:87d6bdaf](https://github.com/ansible/ansible/commit/87d6bdaf9819fdc45a5d309e5e54f8b6f6651ada#diff-cea95d98d811de152d48d1b19ff32e67) & [ansible:66743f33](https://github.com/ansible/ansible/commit/66743f33faa71d092557f2c89788868ca32061aa#diff-64ff7b7878e4bc7c20ce303538b1e583)), I already have an ansible branch [ready](https://github.com/ansible/ansible/compare/devel...dericcrago:govmomi_v0.18.0) for if / when this gets merged / tagged