### PR TITLE
bumped govmomi to v0.19.0 and base container to golang:1.11.2-alpine3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.10.2-alpine3.7
+FROM golang:1.11.2-alpine3.8
 
-ARG GOVMOMI_CHECKOUT="tags/v0.18.0"
+ARG GOVMOMI_CHECKOUT="tags/v0.19.0"
 
 ADD requirements.txt /root/requirements.txt
 


### PR DESCRIPTION
bumped govmomi to v0.19.0 and base container to golang:1.11.2-alpine3.8

changes to vcsim:

```
$ git log --oneline v0.18.0..v0.19.0 -- simulator vcsim
64d875b Added PerformanceManager simulator
f326096 vcsim: add dvpg networks to HostSystem.Parent
10392ff Merge pull request #1192 from thib-ack/maxWaitSecondsSimulator
8e04e3c Run goimports on go source files
17352fc vcsim: add support for tags API
c29d4b1 vcsim: Logout should not unregister PropertyCollector singleton
8bda0ee Fix format in test
8be5207 Add test for WaitOption.MaxWaitSeconds == 0 behaviour in simulator
900e1a3 Fix the WaitOption.MaxWaitSeconds == 0 behaviour in simulator
11fb0d5 vcsim: add ResetVM and SuspendVM support
39e6592 vcsim: add support for PropertyCollector incremental updates
619fbe2 vcsim: do not include DVS in HostSystem.Network
```