### PR TITLE
Use govcsim version v0.20.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.11.9-alpine3.9
 
-ARG GOVMOMI_CHECKOUT="tags/v0.20.0"
+ARG GOVMOMI_CHECKOUT="tags/v0.20.2"
 
 ADD requirements.txt /root/requirements.txt
 


### PR DESCRIPTION
This version is required to handle datastore testcases.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>