### PR TITLE
Use govcsim version v0.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.11.9-alpine3.9
 
-ARG GOVMOMI_CHECKOUT="tags/v0.20.2"
+ARG GOVMOMI_CHECKOUT="tags/v0.21.0"
 
 ADD requirements.txt /root/requirements.txt
 

--- a/flask_control.py
+++ b/flask_control.py
@@ -139,7 +139,7 @@ def spawn_vcsim():
     # build the command
     cmd = [
         VCSIMPATH,
-        '-httptest.serve',
+        '-l',
         '%s:%s' % (hostname, port),
     ]
 


### PR DESCRIPTION
This version is required to handle DistributedPortgroup testcases.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>